### PR TITLE
Update Github Action

### DIFF
--- a/.github/workflows/twitter-together.yml
+++ b/.github/workflows/twitter-together.yml
@@ -1,17 +1,19 @@
-on: [push, pull_request]
+on: [push, pull_request_target]
 name: Twitter, together!
 jobs:
   preview:
     name: Preview
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
+    permissions:
+      pull-requests: write
     steps:
       - name: checkout pull request
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}    
       - name: Validate Tweets
-        uses: IstoraMandiri/twitter-together@etc
+        uses: IstoraMandiri/twitter-together@etc-dev
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   tweet:
@@ -22,7 +24,7 @@ jobs:
       - name: checkout main
         uses: actions/checkout@v3
       - name: Tweet
-        uses: IstoraMandiri/twitter-together@etc
+        uses: IstoraMandiri/twitter-together@etc-dev
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}

--- a/.github/workflows/twitter-together.yml
+++ b/.github/workflows/twitter-together.yml
@@ -11,9 +11,9 @@ jobs:
       - name: checkout pull request
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}    
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Validate Tweets
-        uses: IstoraMandiri/twitter-together@etc-dev
+        uses: IstoraMandiri/twitter-together@etc
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   tweet:
@@ -24,7 +24,7 @@ jobs:
       - name: checkout main
         uses: actions/checkout@v3
       - name: Tweet
-        uses: IstoraMandiri/twitter-together@etc-dev
+        uses: IstoraMandiri/twitter-together@etc
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}


### PR DESCRIPTION
This PR upgrades the workflow to use the latest IstoraMandiri/twitter-together@etc build that enables previews on PRs from forked repos.

eg. https://github.com/ethereumclassic/tweets-etc_network/pull/92